### PR TITLE
Refactor user creation hashing

### DIFF
--- a/app/lib/functions.ts
+++ b/app/lib/functions.ts
@@ -29,17 +29,16 @@ export async function createUser(name: string, email: string, password: string, 
     // Create the user object and insert it into users.json
     const color = generateColor();
     const picture = `https://api.dicebear.com/9.x/adventurer/svg?seed=${name}&flip=true&backgroundColor=${color}`;
-   try {
-        // Hash the password
-        bcrypt.genSalt(10, (err, salt) => {
-            bcrypt.hash(password, salt, async (err, hash) => {
-                // Insert the user into the database
-                await sql`INSERT INTO users (id, name, email, password, image, accounttype) VALUES (${id}, ${name}, ${email}, ${hash}, ${picture}, ${accountType})`;
-            });
-        });
-   } catch (error) {
+    try {
+        const hashedPassword = await bcrypt.hash(password, 10);
+        await sql`INSERT INTO users (id, name, email, password, image, accounttype) VALUES (${id}, ${name}, ${email}, ${hashedPassword}, ${picture}, ${accountType})`;
+    } catch (error) {
         console.error('Failed to create user:', error);
-   }
+        if (error instanceof Error) {
+            throw error;
+        }
+        throw new Error('Failed to create user');
+    }
 }
 
 export async function getUserMeals(userEmail: string): Promise<Array<QueryResultRow>> {


### PR DESCRIPTION
## Summary
- replace the nested bcrypt callbacks with an awaited hash call
- wrap the password hashing and user insert in a try/catch and rethrow unexpected errors
- await the SQL insert to ensure the user is persisted before returning

## Testing
- npm run lint *(fails: `next` binary missing because dependencies could not be installed due to a react peer dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68c86c9f105c8321a3f06b54c00f920d